### PR TITLE
Update Ticker.h

### DIFF
--- a/libraries/Ticker/Ticker.h
+++ b/libraries/Ticker/Ticker.h
@@ -93,6 +93,7 @@ public:
 
 	void once_ms(uint32_t milliseconds, TickerFunction tf)
 	{
+		internalTicker = tf;
 		once_ms(milliseconds, internalCallback, (void*)this);
 	}
 


### PR DESCRIPTION
Small bug fix in which the TickerFunction that was passed to: void once_ms(uint32_t milliseconds, TickerFunction tf) was ignored.